### PR TITLE
[#83] refactor: board API Logs 역순정렬 후 반환하도록 수정

### DIFF
--- a/BE/src/main/java/kr/codesquad/todo9/api/TodoAPIController.java
+++ b/BE/src/main/java/kr/codesquad/todo9/api/TodoAPIController.java
@@ -141,6 +141,7 @@ public class TodoAPIController {
         for (Column column : columns) {
             Collections.sort(column.getCards());
         }
+        Collections.reverse(board.getLogs());
         return board;
     }
 


### PR DESCRIPTION
- board API에서 log목록을 역순으로 정렬후 반환하도록 합니다.

Fixed #83 Issue.
