### PR TITLE
[#26] feat: boardKey에 해당하는 log 객체를 반환하는 API 구현

### DIFF
--- a/BE/src/main/java/kr/codesquad/todo9/api/TodoAPIController.java
+++ b/BE/src/main/java/kr/codesquad/todo9/api/TodoAPIController.java
@@ -149,4 +149,18 @@ public class TodoAPIController {
     public Board showBoard() {
         return showBoard(defaultBoardId);
     }
+
+    @GetMapping("/board/{boardId}/log/{boardKey}")
+    public Log showLog(@PathVariable Long boardId, @PathVariable int boardKey) {
+        List<Log> logs = boardRepository.findById(boardId).orElseThrow(RuntimeException::new).getLogs();
+        if (logs.size() < boardKey) {
+            throw new RuntimeException("해당하는 로그를 찾지 못했습니다.");
+        }
+        return logs.get(boardKey - 1);
+    }
+
+    @GetMapping("/log/{boardKey}")
+    public Log showLog(@PathVariable int boardKey) {
+        return showLog(defaultBoardId, boardKey);
+    }
 }


### PR DESCRIPTION
### boardKey에 해당하는 Log 객체를 반환하는 API가 추가되었습니다.

`log/{boardKey}` 의 형식으로 요청을 보내시면 됩니다.

- 구현하기 전에 든 생각이, 이 API가 필요할지 잘 모르겠습니다!
- 일단 만들어보고 생각하기로 했습니다.
Close #26 Issue.