### PR TITLE
[FE] 카드 이동, 삭제 시 dataset 변경 

### DIFF
--- a/FE/src/ts/column.ts
+++ b/FE/src/ts/column.ts
@@ -4,6 +4,7 @@ import IView from "./view";
 import Activity from "./Activity";
 import EditNote from "./editnote";
 import EditColumn from "./editcolumn";
+import updateDataset from "./updateDataset";
 import {
   getColumnWrap,
   getColumnHeader,
@@ -101,6 +102,7 @@ class Column extends MoveCard implements IView {
     fetchRequest(cvtURI, METHOD.DELETE)
       .then((response) => response.json())
       .then((data) => {
+        updateDataset(data);
         this.activity.appendActivity(data);
       });
   }
@@ -151,7 +153,10 @@ class Column extends MoveCard implements IView {
         const cardId: string = data.afterCard.id;
         const cardKey: string = data.afterCard.columnKey;
 
-        cardList?.insertAdjacentHTML("afterbegin", cardTemplate(cardId, cardKey, this.inputValue, data.user.username));
+        cardList?.insertAdjacentHTML(
+          "afterbegin",
+          cardTemplate(cardId, cardKey, this.inputValue, data.user.username)
+        );
         cardCount.innerText = cardId;
 
         input.value = null;

--- a/FE/src/ts/editnote.ts
+++ b/FE/src/ts/editnote.ts
@@ -2,6 +2,7 @@ import "../style/edit-note.css";
 import Activity from "./activity";
 import Modal from "./modal";
 import fetchRequest from "./common/fetchRequest";
+import updateDataset from "./updateDataset";
 import { SERVICE_URL, INIT_DATA_URI, EDIT_DATA_URI } from "./common/configs";
 import { METHOD } from "./common/constants";
 

--- a/FE/src/ts/moveCard.ts
+++ b/FE/src/ts/moveCard.ts
@@ -1,4 +1,5 @@
 import fetchRequest from "./common/fetchRequest";
+import updateDataset from "./updateDataset";
 import Activity from "./activity";
 import { METHOD } from "./common/constants";
 import { SERVICE_URL, MOVE_URI } from "./common/configs";
@@ -82,6 +83,7 @@ class MoveCard {
     fetchRequest(cvtURI, METHOD.PATCH, body)
       .then((response) => response.json())
       .then((data) => {
+        updateDataset(data);
         this.activity.appendActivity(data);
       })
       .catch((error) => {

--- a/FE/src/ts/updateDataset.ts
+++ b/FE/src/ts/updateDataset.ts
@@ -1,0 +1,22 @@
+import { qsAll$ } from "./lib/util";
+
+const updateDataset = (data: { fromColumn: any; toColumn: any }) => {
+  const { fromColumn, toColumn } = data;
+  const beforeColumn = qsAll$(".column")[fromColumn.boardKey];
+  const afterColumn = qsAll$(".column")[toColumn.boardKey];
+  const beforCards = beforeColumn.querySelectorAll(".card");
+  const afterCards = afterColumn.querySelectorAll(".card");
+
+  change(fromColumn, beforCards);
+  change(toColumn, afterCards);
+};
+
+const change = (column, cards) => {
+  const reverseCards = column.cards.reverse();
+
+  cards.forEach((card: { dataset: { cardKey: any } }, index: any) => {
+    card.dataset.cardKey = reverseCards[index].columnKey;
+  });
+};
+
+export default updateDataset;


### PR DESCRIPTION
### 구현한 내용

- 카드 이동, 삭제 시 dataset 변경하게 함
- 서버에서 보내주는 로그 정보를 바탕으로 변경시킴
- 데이터셋만 변경시켜 추가적인 랜더링이 없도록 함